### PR TITLE
[share] Don't nullify method channel's call handler when detached from Activity

### DIFF
--- a/packages/share/android/src/main/java/io/flutter/plugins/share/SharePlugin.java
+++ b/packages/share/android/src/main/java/io/flutter/plugins/share/SharePlugin.java
@@ -32,9 +32,7 @@ public class SharePlugin implements FlutterPlugin, ActivityAware {
 
   @Override
   public void onDetachedFromEngine(FlutterPluginBinding binding) {
-    methodChannel.setMethodCallHandler(null);
-    methodChannel = null;
-    share = null;
+    tearDownChannel();
   }
 
   @Override
@@ -44,7 +42,7 @@ public class SharePlugin implements FlutterPlugin, ActivityAware {
 
   @Override
   public void onDetachedFromActivity() {
-    tearDownChannel();
+    share.setActivity(null);
   }
 
   @Override
@@ -65,7 +63,8 @@ public class SharePlugin implements FlutterPlugin, ActivityAware {
   }
 
   private void tearDownChannel() {
-    share.setActivity(null);
     methodChannel.setMethodCallHandler(null);
+    methodChannel = null;
+    share = null;
   }
 }


### PR DESCRIPTION
## Description

In an add-to-app Android application, the `share` method channel is set up with the appropriate `MethodCallHandler` set when the plugin attaches to the Flutter engine. When the Android app launches a `FlutterActivity`, `onAttachedToActivity` is called to set the activity on the `Share` instance and invoking `share` works initially. Once the `FlutterActivity` is dismissed and you're taken back to native, `onDetachedFromActivity` is executed which nullifies the activity on the `Share` instance as well as the `MethodCallHandler` on the method channel. Subsequent launches of `FlutterActivity` never rebind the `MethodCallHandler` on the share method channel so any calls to `share` will then fail with:
```
Unhandled Exception: MissingPluginException(No implementation found for method share on channel plugins.flutter.io/share)
```

The solution here is to not nullify the `MethodCallHandler` when the `FlutterActivity` is detached and only nullifying the activity on the `Share` instance.

## Related Issues

*Replace this paragraph with a list of issues related to this PR from the [issue database](https://github.com/flutter/flutter/issues). Indicate, which of these issues are resolved or fixed by this PR. Note that you'll have to prefix the issue numbers with flutter/flutter#.*

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [ ] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. [shared_preferences]
- [ ] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [ ] I updated CHANGELOG.md to add a description of the change.
- [ ] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://www.dartlang.org/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
