### PR TITLE
[share] Show the share text in the iOS share preview panel

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -57,3 +57,4 @@ Ryo Miyake <ryo@miyake.id>
 Théo Champion <contact.theochampion@gmail.com>
 Kazuki Yamaguchi <y.kazuki0614n@gmail.com>
 Eitan Schwartz <eshvartz@gmail.com>
+Jorge Galvão <jmfgalvao@gmail.com>

--- a/packages/share/CHANGELOG.md
+++ b/packages/share/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.6.5
+
+* Show the share text in the iOS share preview panel.
+
 ## 0.6.4+3
 
 * Post-v2 Android embedding cleanup.

--- a/packages/share/ios/Classes/FLTSharePlugin.m
+++ b/packages/share/ios/Classes/FLTSharePlugin.m
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 #import "FLTSharePlugin.h"
+#import "LinkPresentation/LPLinkMetadata.h"
 
 static NSString *const PLATFORM_CHANNEL = @"plugins.flutter.io/share";
 
@@ -45,6 +46,14 @@ static NSString *const PLATFORM_CHANNEL = @"plugins.flutter.io/share";
 - (NSString *)activityViewController:(UIActivityViewController *)activityViewController
               subjectForActivityType:(UIActivityType)activityType {
   return [_subject isKindOfClass:NSNull.class] ? @"" : _subject;
+}
+
+- (LPLinkMetadata *)activityViewControllerLinkMetadata:
+    (UIActivityViewController *)activityViewController
+    API_AVAILABLE(macos(10.15), ios(13.0), watchos(6.0)) {
+  LPLinkMetadata *metadata = [[LPLinkMetadata alloc] init];
+  metadata.title = _text;
+  return metadata;
 }
 
 @end

--- a/packages/share/ios/share.podspec
+++ b/packages/share/ios/share.podspec
@@ -17,6 +17,7 @@ Downloaded by pub (not CocoaPods).
   s.source_files = 'Classes/**/*'
   s.public_header_files = 'Classes/**/*.h'
   s.dependency 'Flutter'
+  s.ios.framework = 'LinkPresentation'
   
   s.platform = :ios, '8.0'
   s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES', 'VALID_ARCHS[sdk=iphonesimulator*]' => 'x86_64' }

--- a/packages/share/pubspec.yaml
+++ b/packages/share/pubspec.yaml
@@ -5,7 +5,7 @@ homepage: https://github.com/flutter/plugins/tree/master/packages/share
 # 0.6.y+z is compatible with 1.0.0, if you land a breaking change bump
 # the version to 2.0.0.
 # See more details: https://github.com/flutter/flutter/wiki/Package-migration-to-1.0.0
-version: 0.6.4+3
+version: 0.6.5
 
 flutter:
   plugin:


### PR DESCRIPTION
From https://github.com/flutter/plugins/pull/2825

## Description

Show the share text in the iOS share preview panel.

Before it just didn't show any preview of the text being shared.

## Related Issues

N/A.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [ ] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [ ] I read and followed the [Flutter Style Guide].
- [ ] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. [shared_preferences]
- [ ] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [ ] I updated CHANGELOG.md to add a description of the change.
- [ ] I signed the [CLA].
- [ ] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [ ] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://www.dartlang.org/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
